### PR TITLE
Ignore message_info blocks of type 0 and emit a warning.

### DIFF
--- a/keynote_parser/__init__.py
+++ b/keynote_parser/__init__.py
@@ -5,7 +5,7 @@ __author__ = "Peter Sobot"
 import keynote_parser.macos_app_version
 
 __major_version__ = 1
-__patch_version__ = 1
+__patch_version__ = 2
 __supported_keynote_version__ = keynote_parser.macos_app_version.MacOSAppVersion(
     "10.0", "6748", "1A171"
 )

--- a/keynote_parser/codec.py
+++ b/keynote_parser/codec.py
@@ -8,6 +8,7 @@ import yaml
 import struct
 import snappy
 import traceback
+import warnings
 
 from .mapping import NAME_CLASS_MAP, ID_NAME_MAP
 
@@ -18,6 +19,17 @@ from google.protobuf.json_format import MessageToDict, ParseDict
 from .generated.TSPArchiveMessages_pb2 import ArchiveInfo
 
 
+class NotImplementedWarning(RuntimeWarning):
+    def __init__(self, file):
+        super(NotImplementedWarning, self).__init__(
+            (
+                "File %s uses 'should_merge' - not yet sure how to handle. "
+                "Some data, builds, transitions, or other features may be lost."
+            )
+            % file
+        )
+
+
 class IWAFile(object):
     def __init__(self, chunks):
         self.chunks = chunks
@@ -25,33 +37,26 @@ class IWAFile(object):
     @classmethod
     def from_file(cls, filename):
         with open(filename) as f:
-            return cls.from_buffer(f.read())
+            return cls.from_buffer(f.read(), filename)
 
     @classmethod
-    def from_buffer(cls, data):
+    def from_buffer(cls, data, filename):
         chunks = []
         while data:
-            chunk, data = IWACompressedChunk.from_buffer(data)
+            chunk, data = IWACompressedChunk.from_buffer(data, filename)
             chunks.append(chunk)
 
         return cls(chunks)
 
     @classmethod
     def from_dict(cls, _dict):
-        return cls([
-            IWACompressedChunk.from_dict(chunk)
-            for chunk in _dict['chunks']
-        ])
+        return cls([IWACompressedChunk.from_dict(chunk) for chunk in _dict['chunks']])
 
     def to_dict(self):
-        return {
-            "chunks": [chunk.to_dict() for chunk in self.chunks]
-        }
+        return {"chunks": [chunk.to_dict() for chunk in self.chunks]}
 
     def to_buffer(self):
-        return b''.join([
-            chunk.to_buffer() for chunk in self.chunks
-        ])
+        return b''.join([chunk.to_buffer() for chunk in self.chunks])
 
 
 class IWACompressedChunk(object):
@@ -68,14 +73,12 @@ class IWACompressedChunk(object):
                 first_byte = ord(first_byte)
 
             if first_byte != 0x00:
-                raise ValueError(
-                    "IWA chunk does not start with 0x00! (found %x)" %
-                    first_byte)
+                raise ValueError("IWA chunk does not start with 0x00! (found %x)" % first_byte)
 
             unpacked = struct.unpack_from('<I', bytes(header[1:]) + b'\x00')
             length = unpacked[0]
-            chunk = data[4:4 + length]
-            data = data[4 + length:]
+            chunk = data[4 : 4 + length]
+            data = data[4 + length :]
 
             try:
                 yield snappy.uncompress(chunk)
@@ -86,11 +89,11 @@ class IWACompressedChunk(object):
                 yield chunk
 
     @classmethod
-    def from_buffer(cls, data):
+    def from_buffer(cls, data, filename):
         data = b''.join(cls._decompress_all(data))
         archives = []
         while data:
-            archive, data = IWAArchiveSegment.from_buffer(data)
+            archive, data = IWAArchiveSegment.from_buffer(data, filename)
             archives.append(archive)
         return cls(archives), None
 
@@ -99,16 +102,10 @@ class IWACompressedChunk(object):
         return cls([IWAArchiveSegment.from_dict(d) for d in _dict['archives']])
 
     def to_dict(self):
-        return {
-            "archives": [
-                archive.to_dict() for archive in self.archives
-            ]
-        }
+        return {"archives": [archive.to_dict() for archive in self.archives]}
 
     def to_buffer(self):
-        payload = snappy.compress(b''.join([
-            archive.to_buffer() for archive in self.archives
-        ]))
+        payload = snappy.compress(b''.join([archive.to_buffer() for archive in self.archives]))
         return b'\x00' + struct.pack('<I', len(payload))[:3] + payload
 
 
@@ -121,28 +118,33 @@ class IWAArchiveSegment(object):
         return self.header == other.header and self.objects == other.objects
 
     @classmethod
-    def from_buffer(cls, buf):
+    def from_buffer(cls, buf, filename):
         archive_info, payload = get_archive_info_and_remainder(buf)
         if not repr(archive_info):
-            raise ValueError(
-                "Segment doesn't seem to start with an ArchiveInfo!")
+            raise ValueError("Segment doesn't seem to start with an ArchiveInfo!")
 
         payloads = []
 
         n = 0
         for message_info in archive_info.message_infos:
+            if message_info.type == 0:
+                if archive_info.should_merge:
+                    warnings.warn(NotImplementedWarning(filename))
+                    n += message_info.length
+                    continue
             try:
                 klass = ID_NAME_MAP[message_info.type]
             except KeyError:
                 raise NotImplementedError(
-                    "Don't know how to parse Protobuf message type " +
-                    str(message_info.type))
+                    "Don't know how to parse Protobuf message type " + str(message_info.type)
+                )
             try:
-                output = klass.FromString(payload[n:n + message_info.length])
+                output = klass.FromString(payload[n : n + message_info.length])
             except Exception as e:
                 raise ValueError(
-                    "Failed to deserialize %s payload of length %d: %s" % (
-                        klass, message_info.length, e))
+                    "Failed to deserialize %s payload of length %d: %s"
+                    % (klass, message_info.length, e)
+                )
             payloads.append(output)
             n += message_info.length
 
@@ -150,9 +152,7 @@ class IWAArchiveSegment(object):
 
     @classmethod
     def from_dict(cls, _dict):
-        return cls(
-            dict_to_header(_dict['header']),
-            [dict_to_message(o) for o in _dict['objects']])
+        return cls(dict_to_header(_dict['header']), [dict_to_message(o) for o in _dict['objects']])
 
     def to_dict(self):
         return {
@@ -168,12 +168,10 @@ class IWAArchiveSegment(object):
             provided_length = message_info.length
             if object_length != provided_length:
                 message_info.length = object_length
-        return b''.join([
-            _VarintBytes(self.header.ByteSize()),
-            self.header.SerializeToString()
-        ] + [
-            obj.SerializeToString() for obj in self.objects
-        ])
+        return b''.join(
+            [_VarintBytes(self.header.ByteSize()), self.header.SerializeToString()]
+            + [obj.SerializeToString() for obj in self.objects]
+        )
 
 
 def message_to_dict(message):
@@ -192,10 +190,7 @@ def header_to_dict(message):
 def dict_to_message(_dict):
     _type = _dict['_pbtype']
     del _dict['_pbtype']
-    return ParseDict(
-        _dict,
-        NAME_CLASS_MAP[_type](),
-        ignore_unknown_fields=True)
+    return ParseDict(_dict, NAME_CLASS_MAP[_type](), ignore_unknown_fields=True)
 
 
 def dict_to_header(_dict):
@@ -208,7 +203,7 @@ def dict_to_header(_dict):
 def get_archive_info_and_remainder(buf):
     msg_len, new_pos = _DecodeVarint32(buf, 0)
     n = new_pos
-    msg_buf = buf[n:n + msg_len]
+    msg_buf = buf[n : n + msg_len]
     n += msg_len
     return ArchiveInfo.FromString(msg_buf), buf[n:]
 
@@ -217,8 +212,6 @@ if __name__ == "__main__":
     for filename in sys.argv[1:]:
         try:
             iwa_file = IWAFile.from_file(filename)
-            print(yaml.safe_dump(
-                iwa_file.to_dict(),
-                default_flow_style=False))
+            print(yaml.safe_dump(iwa_file.to_dict(), default_flow_style=False))
         except Exception as e:
             print("FAILED", traceback.format_exc(e))

--- a/keynote_parser/file_utils.py
+++ b/keynote_parser/file_utils.py
@@ -154,7 +154,7 @@ def process_file(filename, handle, sink, replacements=[], raw=False, on_replace=
             file = IWAFile.from_dict(yaml.load(fix_unicode(contents.decode('utf-8'))))
             filename = filename.replace('.yaml', '')
         else:
-            file = IWAFile.from_buffer(contents)
+            file = IWAFile.from_buffer(contents, filename)
 
         file_has_changed = False
         for replacement in replacements:

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -14,7 +14,7 @@ EMOJI_FILENAME_PY3_YAML = './tests/data/emoji-oneslide.py3.yaml'
 def roundtrip(filename):
     with open(filename, 'rb') as f:
         test_data = f.read()
-    file = codec.IWAFile.from_buffer(test_data)
+    file = codec.IWAFile.from_buffer(test_data, filename)
     assert file is not None
     assert file.to_buffer() == test_data
 
@@ -33,22 +33,20 @@ def test_iwa_emoji_roundtrip():
 
 def test_yaml_parse_py2_emoji():
     with open(EMOJI_FILENAME_PY2_YAML, 'rb') as handle:
-        file = codec.IWAFile.from_dict(yaml.load(
-            fix_unicode(handle.read().decode('utf-8'))))
+        file = codec.IWAFile.from_dict(yaml.load(fix_unicode(handle.read().decode('utf-8'))))
         assert file is not None
 
 
 def test_yaml_parse_py3_emoji():
     with open(EMOJI_FILENAME_PY3_YAML, 'rb') as handle:
-        file = codec.IWAFile.from_dict(yaml.load(
-            fix_unicode(handle.read().decode('utf-8'))))
+        file = codec.IWAFile.from_dict(yaml.load(fix_unicode(handle.read().decode('utf-8'))))
         assert file is not None
 
 
 def test_iwa_multichunk_roundtrip():
     with open(MULTICHUNK_FILENAME, 'rb') as f:
         test_data = f.read()
-    file = codec.IWAFile.from_buffer(test_data)
+    file = codec.IWAFile.from_buffer(test_data, MULTICHUNK_FILENAME)
     assert file is not None
-    rt_as_dict = codec.IWAFile.from_buffer(file.to_buffer()).to_dict()
+    rt_as_dict = codec.IWAFile.from_buffer(file.to_buffer(), MULTICHUNK_FILENAME).to_dict()
     assert rt_as_dict == file.to_dict()

--- a/tests/test_replacement.py
+++ b/tests/test_replacement.py
@@ -8,7 +8,7 @@ MULTILINE_SURROGATE_FILENAME = './tests/data/multiline-surrogate.iwa'
 def test_iwa_multiline_surrogate_replacement():
     with open(MULTILINE_SURROGATE_FILENAME, 'rb') as f:
         test_data = f.read()
-    file = codec.IWAFile.from_buffer(test_data)
+    file = codec.IWAFile.from_buffer(test_data, MULTILINE_SURROGATE_FILENAME)
     data = file.to_dict()
     replacement = Replacement("\\$REPLACE_ME", "replaced!")
     replaced = replacement.perform_on(data)


### PR DESCRIPTION
Temporary patch for #16 - this ignores any `message_info` blocks with type `0`, which may result in data loss, but in practise, I didn't see any difference.