### PR TITLE
Fixed multibyte surrogate parsing with pairs that look like multibyte surrogate pairs, but aren't.

### DIFF
--- a/keynote_parser/__init__.py
+++ b/keynote_parser/__init__.py
@@ -5,7 +5,7 @@ __author__ = "Peter Sobot"
 import keynote_parser.macos_app_version
 
 __major_version__ = 1
-__patch_version__ = 3
+__patch_version__ = 4
 __supported_keynote_version__ = keynote_parser.macos_app_version.MacOSAppVersion(
     "10.0", "6748", "1A171"
 )

--- a/keynote_parser/file_utils.py
+++ b/keynote_parser/file_utils.py
@@ -151,7 +151,7 @@ def process_file(filename, handle, sink, replacements=[], raw=False, on_replace=
     if '.iwa' in filename and not raw:
         contents = handle.read()
         if filename.endswith('.yaml'):
-            file = IWAFile.from_dict(yaml.load(fix_unicode(contents.decode('utf-8'))))
+            file = IWAFile.from_dict(yaml.safe_load(fix_unicode(contents.decode('utf-8'))))
             filename = filename.replace('.yaml', '')
         else:
             file = IWAFile.from_buffer(contents, filename)

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -43,13 +43,13 @@ def test_iwa_message_type_zero_roundtrip():
 
 def test_yaml_parse_py2_emoji():
     with open(EMOJI_FILENAME_PY2_YAML, 'rb') as handle:
-        file = codec.IWAFile.from_dict(yaml.load(fix_unicode(handle.read().decode('utf-8'))))
+        file = codec.IWAFile.from_dict(yaml.safe_load(fix_unicode(handle.read().decode('utf-8'))))
         assert file is not None
 
 
 def test_yaml_parse_py3_emoji():
     with open(EMOJI_FILENAME_PY3_YAML, 'rb') as handle:
-        file = codec.IWAFile.from_dict(yaml.load(fix_unicode(handle.read().decode('utf-8'))))
+        file = codec.IWAFile.from_dict(yaml.safe_load(fix_unicode(handle.read().decode('utf-8'))))
         assert file is not None
 
 

--- a/tests/test_unicode_utils.py
+++ b/tests/test_unicode_utils.py
@@ -1,5 +1,4 @@
-from keynote_parser.unicode_utils import \
-    fix_unicode, to_py3_compatible, to_py2_compatible
+from keynote_parser.unicode_utils import fix_unicode, to_py3_compatible, to_py2_compatible
 
 
 def test_non_surrogate_pair():
@@ -9,13 +8,16 @@ def test_non_surrogate_pair():
 
 
 def test_surrogate_pair():
-    assert to_py2_compatible(r'\U0001F1E8\U0001F1E6') \
-        == r'\ud83c\udde8\ud83c\udde6'
-    assert to_py3_compatible(r'\ud83c\udde8\ud83c\udde6') \
-        == r'\U0001f1e8\U0001f1e6'
+    assert to_py2_compatible(r'\U0001F1E8\U0001F1E6') == r'\ud83c\udde8\ud83c\udde6'
+    assert to_py3_compatible(r'\ud83c\udde8\ud83c\udde6') == r'\U0001f1e8\U0001f1e6'
 
 
 def test_basic_multilingual_plane():
     srpska = r'\u0441\u0440\u043f\u0441\u043a\u0430'
     assert to_py2_compatible(srpska) == srpska
     assert to_py3_compatible(srpska) == srpska
+
+
+def test_german_example():
+    deutsch_nicht_ersatzpaar = br'\uFFFC\u201C."'.decode('utf-8')
+    assert fix_unicode(deutsch_nicht_ersatzpaar) == deutsch_nicht_ersatzpaar


### PR DESCRIPTION
Fixes #19. (Thanks @kortenkamp!)

This bug surfaced due to a slight misconfiguration in how `keynote-parser` handles [multi-byte Unicode surrogate characters](https://en.wikipedia.org/wiki/UTF-16#Description) (added in #4). Any pairs of escaped characters that look like `\Uaaaa\Ubbbb` were caught by the `fix_unicode` function, when valid multibyte surrogate pairs can only be in the _high_ or _low_ ranges. [From Wikipedia](https://en.wikipedia.org/wiki/UTF-16#Description):

> Since the ranges for the high surrogates (`0xD800–0xDBFF`), low surrogates (`0xDC00–0xDFFF`), and valid BMP characters (`0x0000–0xD7FF`, `0xE000–0xFFFF`) are disjoint, it is not possible for a surrogate to match a BMP character, or for two adjacent code units to look like a legal surrogate pair.

Before this PR, the regex for identifying surrogate pairs looked for _any_ characters that looked like a surrogate pair, regardless of if they fit into the high surrogate or low surrogate ranges. This PR fixes the issue by changing the regex from `\\u([A-Fa-f0-9]{4})\\u([A-Fa-f0-9]{4})` to `r'\\u([Dd][89a-bA-B][0-9a-fA-F]{2})\\u([Dd][c-fC-F][0-9a-fA-F]{2})'`, which matches a high surrogate followed by a low surrogate, rather than any pair of valid characters in the [BMP](https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane), including the combination of [`\uFFFC` (the object replacement character)](https://en.wiktionary.org/wiki/%EF%BF%BC#:~:text=(computing)%20The%20object%20replacement%20character,is%20converted%20to%20plain%20text.) followed by [`\u201C` (the left double quotation mark)](https://www.toptal.com/designers/htmlarrows/punctuation/left-double-quotation-mark/), as encountered in #19.