### PR TITLE
Fix parsing of float values with Protobuf >= 3.13.0.

### DIFF
--- a/keynote_parser/__init__.py
+++ b/keynote_parser/__init__.py
@@ -5,7 +5,7 @@ __author__ = "Peter Sobot"
 import keynote_parser.macos_app_version
 
 __major_version__ = 1
-__patch_version__ = 0
+__patch_version__ = 1
 __supported_keynote_version__ = keynote_parser.macos_app_version.MacOSAppVersion(
     "10.1", "6913", "1A148"
 )

--- a/setup.py
+++ b/setup.py
@@ -148,12 +148,12 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'protobuf>=3.8.0',
+        'protobuf>=3.13.0',
         'tqdm>=4.14.0',
         'python-snappy>=0.5.3',
-        'PyYAML>=4.2b1',
-        'Pillow==6.2.2',
-        'future==0.17.1',
+        'PyYAML>=5.3.1',
+        'Pillow>=6.2.2',
+        'future>=0.17.1',
         'colorama>=0.4.3',
     ],
     # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
cc @kortenkamp - this should fix the (hopefully final!) [issues you were running into after #23 was merged](https://github.com/psobot/keynote-parser/pull/23#issuecomment-679100396).