### PR TITLE
Fix proto2 extension field handling and improve dumper compatibility with recent Keynote versions (e.g. Keynote 15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,30 @@ created by older versions of `keynote-parser`:
 
 As `keynote-parser` includes Protobuf definitions extracted from a copy of Keynote,
 new versions of Keynote will inevitably create `.key` files that cannot be read by `keynote-parser`.
-As new versions of Keynote are released, updates to `keynote-parser` can be made automatically
-by running the following on a macOS machine with Keynote installed:
+When a new version of Keynote is installed, run the following on that macOS machine to regenerate
+the mappings and compiled Protobuf files:
 
 ```shell
-cd dumper
-make clean
-make
+PYTHONPATH=$PYTHONPATH:$(pwd) uv run --python /opt/homebrew/bin/python3 dumper/run.py --app-path "/Applications/Keynote.app"
 ```
+
+**Prerequisites:**
+- macOS with Keynote installed
+- [Homebrew](https://brew.sh) Python 3.13: `brew install python@3.13`
+- [LLVM/LLDB](https://llvm.org) matching that Python version: `brew install llvm`
+- `protoc`: `brew install protobuf`
+
+**Notes:**
+- The app path may differ depending on the Keynote version installed
+  (e.g. `/Applications/Keynote 2025.app`). Check your `/Applications` folder.
+- `uv run --python /opt/homebrew/bin/python3` is required because the LLDB Python bindings
+  must match the Homebrew Python that LLDB was compiled against. Using `uv`'s bundled Python
+  will cause a silent crash.
+- The script will briefly launch Keynote under the debugger to extract the type registry.
+  Keynote may appear on screen momentarily — this is expected.
+- No codesigning certificate is required; the script uses ad-hoc signing (`-`) automatically.
+- The generated files (`keynote_parser/versions/v*/generated/`) are not committed to the
+  repository and must be regenerated locally after cloning.
 
 ## Troubleshooting
 

--- a/dumper/run.py
+++ b/dumper/run.py
@@ -40,18 +40,19 @@ logging.basicConfig(
 def unsigned_copy_of(app_path: str) -> Generator[str, None, None]:
     app_name = os.path.basename(app_path).replace(".app", "")
     unsigned_app_bundle_filename = f"{app_name}.unsigned.app"
+    # The executable name may differ from the bundle name (e.g. "Keynote 2025.app" contains "Keynote")
+    exe_name = plistlib.load(
+        open(os.path.join(app_path, "Contents", "Info.plist"), "rb")
+    )["CFBundleExecutable"]
 
-    # Get the identity from the system:
+    # Get the identity from the system, falling back to ad-hoc signing ("-")
+    # which requires no certificate and is sufficient for LLDB to attach.
     logging.info("Getting codesigning identity...")
-    identity = subprocess.check_output(
+    identity_output = subprocess.check_output(
         ["security", "find-identity", "-v", "-p", "codesigning"]
     ).decode()
-    identity = identity.split('"')[1]
-    if not identity:
-        raise ValueError(
-            "No codesigning identity found; please create one in Keychain Access first."
-        )
-    logging.info(f"Resigning {app_path} with local codesigning identity: {identity!r}")
+    identity = identity_output.split('"')[1] if '"' in identity_output else "-"
+    logging.info(f"Resigning {app_path} with codesigning identity: {identity!r}")
 
     with tempfile.TemporaryDirectory() as temp_dir:
         target = os.path.join(temp_dir, unsigned_app_bundle_filename)
@@ -63,12 +64,12 @@ def unsigned_copy_of(app_path: str) -> Generator[str, None, None]:
                 "codesign",
                 "--remove-signature",
                 "--verbose",
-                os.path.join(target, "Contents", "MacOS", app_name),
+                os.path.join(target, "Contents", "MacOS", exe_name),
             ]
         )
-        # Resign the app with the local identity:
+        # Resign the app with the local identity (or ad-hoc if none available):
         logging.info(
-            f"Resigning {target} with local codesigning identity: {identity!r}"
+            f"Resigning {target} with codesigning identity: {identity!r}"
         )
         subprocess.run(
             [
@@ -76,7 +77,7 @@ def unsigned_copy_of(app_path: str) -> Generator[str, None, None]:
                 "--sign",
                 identity,
                 "--verbose",
-                os.path.join(target, "Contents", "MacOS", app_name),
+                os.path.join(target, "Contents", "MacOS", exe_name),
             ]
         )
         logging.info(f"Successfully re-signed {target}.")

--- a/keynote_parser/codec.py
+++ b/keynote_parser/codec.py
@@ -6,6 +6,7 @@ from functools import partial
 
 import snappy
 import yaml
+from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf.internal.decoder import _DecodeVarint32
 from google.protobuf.internal.encoder import _VarintBytes
 from google.protobuf.json_format import MessageToDict, ParseDict
@@ -170,7 +171,13 @@ class ProtobufPatch(object):
                 "Message info was:\n%s\nObject was:\n%s" % (message_info, data)
             )
         for diff_path in message_info.diff_field_path.path:
-            patched_field = proto_klass.DESCRIPTOR.fields_by_number[diff_path]
+            if diff_path in proto_klass.DESCRIPTOR.fields_by_number:
+                patched_field = proto_klass.DESCRIPTOR.fields_by_number[diff_path]
+            else:
+                # Extension fields (proto2 `extend` blocks) are not in fields_by_number
+                patched_field = _descriptor_pool.Default().FindExtensionByNumber(
+                    proto_klass.DESCRIPTOR, diff_path
+                )
             field_message_class = import_version(version)[1][
                 patched_field.message_type.full_name
             ]


### PR DESCRIPTION
While updating to Keynote 15.1.1 (the latest Keynote as of now), I ran into two bugs that prevented both unpacking `.key` files and running `dumper/run.py`. This PR fixes both, along with a README update to bring the Updates section in line with the current tooling.

## Changes

### `keynote_parser/codec.py` — Fix KeyError on proto2 extension fields

`ProtobufPatch.apply()` assumed all field numbers in `diff_field_path` are present in `fields_by_number`. However, fields defined via proto2 `extend` blocks are not regular message fields and are absent from `fields_by_number`. This caused a `KeyError` when unpacking files containing such fields, which appear in Keynote 15.

The fix looks up extension fields via `descriptor_pool.Default().FindExtensionByNumber()` when the field number is not found in `fields_by_number`.

### `dumper/run.py` — Two compatibility fixes

1. **Executable name derived from `Info.plist`** instead of the bundle folder
   name. Recent Keynote is distributed as `Keynote 2025.app` but its binary is
   named `Keynote`, causing the codesign and re-sign steps to fail with
   "No such file or directory".

2. **Ad-hoc signing fallback** when no local codesigning identity is available.
   The script previously raised an error requiring users to create a certificate
   in Keychain Access. `codesign -s -` (ad-hoc signing) is sufficient for LLDB
   to attach to the process and requires no certificate setup.

### `README.md` — Updated `Updates` section

The `make`-based instructions were outdated. Replaced with the current `dumper/run.py`-based workflow including prerequisites, the correct Python interpreter requirement for LLDB compatibility, and other notes for first-time users.

## Testing

Tested on macOS with Keynote 15.1.1 ("Keynote 2025"). Both `unpack` and `pack` work correctly on `.key` files generated by this version.

## Transparency

This fix was developed with the help of Claude Code.